### PR TITLE
fix: delete redundant password in model and update controller to include password confirmation

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -32,6 +32,6 @@ class Api::V1::UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:username, :password, :first_name, :email)
+    params.require(:user).permit(:username, :password, :password_confirmation, :first_name, :email)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,6 @@ class User < ApplicationRecord
 
   validates :username, presence: true, uniqueness: true
   validates :email, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }
-  validates :password_digest, presence: true
   validates :first_name, length: { maximum: 20 }, allow_nil: true
 
   has_secure_password


### PR DESCRIPTION
This PR deletes the password digest validation in the users model because has_secure_password validates the password. It also adds a password conformation param to user_params. 