### PR TITLE
feat: add logic for blank username/password for sessions login and related tests

### DIFF
--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -1,11 +1,16 @@
 class Api::V1::SessionsController < ApplicationController
   def create
-    user = User.find_by(username: params[:username])
-    if user && user.authenticate(params[:password])
-      render json: UserSerializer.new(user)
+    if params[:username].blank? || params[:password].blank?
+      error_message = ErrorMessage.new("Username and password cannot be blank", 400)
+      render json: ErrorSerializer.format_error(error_message), status: :bad_request
     else
-      error_message = ErrorMessage.new("Invalid login credentials", 401)
-      render json: ErrorSerializer.format_error(error_message), status: :unauthorized
+      user = User.find_by(username: params[:username])
+      if user && user.authenticate(params[:password])
+        render json: UserSerializer.new(user)
+      else
+        error_message = ErrorMessage.new("Invalid login credentials", 401)
+        render json: ErrorSerializer.format_error(error_message), status: :unauthorized
+      end
     end
   end
 end

--- a/spec/requests/api/v1/sessions_request_spec.rb
+++ b/spec/requests/api/v1/sessions_request_spec.rb
@@ -52,5 +52,29 @@ RSpec.describe Api::V1::SessionsController, type: :request do
         expect(parsed_response[:errors].first[:detail]).to eq("Invalid login credentials")
       end
     end
+
+    context "when the username or password are empty" do
+      it "returns an bad request response with an error message" do
+        user_params = { username: "", password: user.password }
+
+        post "/api/v1/sessions", params: user_params.to_json, headers: { "CONTENT_TYPE" => "application/json" }
+        expect(response).to have_http_status(:bad_request)
+
+        parsed_response = JSON.parse(response.body, symbolize_names: true)
+        expect(parsed_response[:errors]).to be_an(Array)
+        expect(parsed_response[:errors].first[:detail]).to eq("Username and password cannot be blank")
+      end
+
+      it "returns an bad request response with an error message" do
+        user_params = { username: user.username, password: "" }
+
+        post "/api/v1/sessions", params: user_params.to_json, headers: { "CONTENT_TYPE" => "application/json" }
+        expect(response).to have_http_status(:bad_request)
+
+        parsed_response = JSON.parse(response.body, symbolize_names: true)
+        expect(parsed_response[:errors]).to be_an(Array)
+        expect(parsed_response[:errors].first[:detail]).to eq("Username and password cannot be blank")
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR adds logic to the sessions controller to return a separate error if a post request makes it to the BE with a blank username and/or password. Blank entries will return a "Username and password cannot be blank" error, while invalid credentials will return an "Invalid login credentials" error.

This PR also adds sad path testing for blank username/password inputs. 